### PR TITLE
Build instructions to generate tar gz necessary for building RPMS

### DIFF
--- a/TET-README.txt
+++ b/TET-README.txt
@@ -1,0 +1,8 @@
+Steps to build release tar.gz:
+
+1) mvn versions:set -DnewVersion=0.99.1234 ( Set to a version which we want to use)
+2) mvn clean package -DskipTests assembly:single -Dassembly.file="hbase-assembly/src/main/assembly/src.xml" -Prelease
+3) Copy the tar.gz as -src.tar.gz
+4) mvn clean install -DskipTests assembly:single -Prelease
+5) Copy the tar.gz as -bin.tar.gz
+6) Run a binary server on the directory with the 2 tar.gz in apache archive dir structure, like hbase/hbase-version/..tar.gz

--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-assembly</artifactId>

--- a/hbase-client/pom.xml
+++ b/hbase-client/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/hbase-common/pom.xml
+++ b/hbase-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/hbase-examples/pom.xml
+++ b/hbase-examples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-examples</artifactId>

--- a/hbase-hadoop-compat/pom.xml
+++ b/hbase-hadoop-compat/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>hbase</artifactId>
         <groupId>org.apache.hbase</groupId>
-        <version>0.98-tet-1</version>
+        <version>0.99.1234</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/hbase-hadoop1-compat/pom.xml
+++ b/hbase-hadoop1-compat/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/hbase-hadoop2-compat/pom.xml
+++ b/hbase-hadoop2-compat/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/hbase-it/pom.xml
+++ b/hbase-it/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/hbase-prefix-tree/pom.xml
+++ b/hbase-prefix-tree/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/hbase-protocol/pom.xml
+++ b/hbase-protocol/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>hbase</artifactId>
         <groupId>org.apache.hbase</groupId>
-        <version>0.98-tet-1</version>
+        <version>0.99.1234</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-server</artifactId>

--- a/hbase-shell/pom.xml
+++ b/hbase-shell/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-shell</artifactId>

--- a/hbase-testing-util/pom.xml
+++ b/hbase-testing-util/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>hbase</artifactId>
         <groupId>org.apache.hbase</groupId>
-        <version>0.98-tet-1</version>
+        <version>0.99.1234</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>hbase-testing-util</artifactId>

--- a/hbase-thrift/pom.xml
+++ b/hbase-thrift/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>hbase</artifactId>
     <groupId>org.apache.hbase</groupId>
-    <version>0.98-tet-1</version>
+    <version>0.99.1234</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>hbase-thrift</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   <groupId>org.apache.hbase</groupId>
   <artifactId>hbase</artifactId>
   <packaging>pom</packaging>
-  <version>0.98-tet-1</version>
+  <version>0.99.1234</version>
   <name>HBase</name>
   <description>
     Apache HBase is the Hadoop database. Use it when you need

--- a/pom.xml
+++ b/pom.xml
@@ -1464,14 +1464,14 @@
           <plugin>
             <groupId>org.apache.rat</groupId>
             <artifactId>apache-rat-plugin</artifactId>
-            <executions>
+		<!-- <executions>
               <execution>
                 <phase>package</phase>
                 <goals>
                   <goal>check</goal>
                 </goals>
               </execution>
-            </executions>
+            </executions> -->
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
CL adds build instructions and pom changes needed for building tar gz which can be used for building rpm.

@andy256 Please review.

cc @vjeyakum 
